### PR TITLE
feat(enums): add missing exports

### DIFF
--- a/src/World.ts
+++ b/src/World.ts
@@ -1,15 +1,21 @@
 import { Entity, Model, Prop } from './';
 import { Blip } from './Blip';
 import { Camera } from './Camera';
-import { CloudHat, IntersectOptions, MarkerType, RopeType, Weather } from './enums';
-import { CameraTypes } from './enums/CameraTypes';
-import { PickupType } from './enums/PickupType';
+import {
+  CameraTypes,
+  CloudHat,
+  IntersectOptions,
+  MarkerType,
+  PickupType,
+  RopeType,
+  Weather,
+} from './enums';
 import { VehicleHash } from './hashes';
 import { Ped, Vehicle } from './models';
 import { Pickup } from './Pickup';
 import { RaycastResult } from './Raycast';
 import { Rope } from './Rope';
-import { Wait, Color, Maths, Vector3 } from './utils';
+import { Color, Maths, Vector3, Wait } from './utils';
 
 /**
  * Class with common world manipulations.

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -35,22 +35,8 @@ export { Relationship } from './Relationship';
 export { RopeType } from './RopeType';
 export { ScreenEffect } from './ScreenEffect';
 export { SpeechModifier } from './SpeechModifier';
-export {
-  VehicleClass,
-  VehicleColor,
-  VehicleLandingGearState,
-  VehicleLockStatus,
-  VehicleNeonLight,
-  VehicleRoofState,
-  VehicleSeat,
-  VehicleWindowTint,
-  VehicleWindowIndex,
-  VehicleModType,
-  VehicleToggleModType,
-  VehiclePaintType,
-  VehicleDoorIndex,
-  VehicleWheelType,
-  VehicleWheelIndex,
-} from './Vehicle';
+export * from './Vehicle';
 export { Weather } from './Weather';
 export { ZoneID } from './ZoneID';
+export { PickupType } from './PickupType';
+export { CameraTypes } from './CameraTypes';

--- a/src/models/VehicleModCollection.ts
+++ b/src/models/VehicleModCollection.ts
@@ -7,10 +7,11 @@ import {
   VehicleToggleModType,
   VehicleWheelType,
   VehicleWindowTint,
+  LicensePlateStyle,
+  LicensePlateType,
 } from '../enums';
 import { VehicleMod } from './VehicleMod';
 import { Color } from '../utils';
-import { LicensePlateStyle, LicensePlateType } from '../enums/Vehicle';
 import { VehicleToggleMod } from './VehicleToggleMod';
 
 export class VehicleModCollection {


### PR DESCRIPTION
Added missing PickupType, CameraTypes exports and exported all vehicle enums instead of exporting each export individually.